### PR TITLE
Add exporter Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN python3 -m venv /venv && \
   python3 -m pip install --upgrade pip setuptools && \
   rm -rf /root/.cache && \
   echo && echo && echo "source /venv/bin/activate" >> /root/.bashrc
-ENV SHELL /bin/bash
+ENV SHELL=/bin/bash
 
 # Install nvitop
 COPY . /nvitop

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Build and run the Docker image using [nvidia-docker](https://github.com/NVIDIA/n
 
 ```bash
 git clone --depth=1 https://github.com/XuehaiPan/nvitop.git && cd nvitop  # clone this repo first
-docker build --tag nvitop:latest .  # build the Docker image
+docker buildx build --tag nvitop:latest .  # build the Docker image
 docker run -it --rm --runtime=nvidia --gpus=all --pid=host nvitop:latest  # run the Docker container
 ```
 

--- a/nvitop-exporter/Dockerfile
+++ b/nvitop-exporter/Dockerfile
@@ -1,0 +1,11 @@
+FROM nvitop:latest
+
+RUN apt-get update && apt-get install -y pipx
+RUN pipx ensurepath
+ENV PATH="/root/.local/bin:$PATH"
+
+WORKDIR /nvitop/nvitop-exporter
+
+RUN pipx install nvitop-exporter
+
+ENTRYPOINT [ "nvitop-exporter", "--bind-address", "0.0.0.0", "--port", "5050" ]

--- a/nvitop-exporter/README.md
+++ b/nvitop-exporter/README.md
@@ -31,6 +31,8 @@ docker buildx build -t nvitop-exporter:latest .
 docker run -it --name nvitop-exporter --rm --runtime=nvidia --gpus=all --pid=host -p 5050:5050 nvitop-exporter:latest
 ```
 
+If you need the exporter to report the local IP, you can replace `-p 5050:5050` with `--network=host`. This gives the container access to the host's network which have security implications, especially in multi-tenant environments.
+
 ## Grafana Dashboard
 
 A Grafana dashboard is provided to visualize the metrics collected by the exporter.

--- a/nvitop-exporter/README.md
+++ b/nvitop-exporter/README.md
@@ -28,7 +28,7 @@ After building `nvitop:latest`
 ```bash
 cd nvitop-exporter/
 docker buildx build -t nvitop-exporter:latest .
-docker run -it --rm --runtime=nvidia --gpus=all --pid=host -p 5050:5050 nvitop-exporter:latest
+docker run -it --name nvitop-exporter --rm --runtime=nvidia --gpus=all --pid=host -p 5050:5050 nvitop-exporter:latest
 ```
 
 ## Grafana Dashboard

--- a/nvitop-exporter/README.md
+++ b/nvitop-exporter/README.md
@@ -23,6 +23,14 @@ scrape_configs:
       - targets: ['localhost:5050']
 ```
 
+### With Docker
+After building `nvitop:latest`
+```bash
+cd nvitop-exporter/
+docker buildx build -t nvitop-exporter:latest .
+docker run -it --rm --runtime=nvidia --gpus=all --pid=host -p 5050:5050 nvitop-exporter:latest
+```
+
 ## Grafana Dashboard
 
 A Grafana dashboard is provided to visualize the metrics collected by the exporter.


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### Issue Type
- Improvement/feature implementation

#### Runtime Environment

_Not really necessary because I'm using Docker._

- Operating system and version: Pop!_OS 22.04 LTS
- Terminal emulator and version: GNOME Terminal 3.44.0 
- Python version: 3.11.7
- NVML version (driver version): 560.35.03
- `nvitop` version or commit: main@254716f1aeaa656401e3978112ad64be6be007f4
- `python-ml-py` version: -
- Locale: en_US.UTF-8

#### Description
* Added Dockerfile to build image for nvitop-exporter
* Added instructions to start exporter
* Updated nvitop Dockerfile due to warning about ENV label

#### Motivation and Context
Changes required to start the exporter in a docker container, without interactive installs.


#### Testing
* Metrics are exposed correctly in http://localhost:5050. It can be consumed normally by Grafana/PRometheus

No other areas are affected.
